### PR TITLE
fix errors: metamask v10.15.0

### DIFF
--- a/dist/Metamask/Libs/addNewNetwork.js
+++ b/dist/Metamask/Libs/addNewNetwork.js
@@ -22,42 +22,34 @@ function addNewNetwork(params) {
         const C = params.C;
         let currentUrl = page.url();
         try {
+            let networkUrl = [
+                C.urls.prefix,
+                currentUrl.match(/\/\/(.*?)\//i)[1],
+                `/home.html#settings/networks`
+            ].join("");
+            yield page.goto(networkUrl, { waitUntil: 'domcontentloaded' });
+            // click add new network
+            yield page.waitForXPath(C.elements.add_new_network.button_add_a_network_xpath + "[not(@disabled)]", { visible: true });
+            const [buttonAddNewNetwork] = yield page.$x(C.elements.add_new_network.button_add_a_network_xpath);
+            yield buttonAddNewNetwork.click();
+            // Type Network Name
+            const [inputNetworkNameXpath] = yield page.$x(C.elements.add_new_network.input_network_name_xpath);
+            yield inputNetworkNameXpath.type(params.networkName);
+            // Type input rpc url
+            const [inputRpcUrlXpath] = yield page.$x(C.elements.add_new_network.input_rpc_url_xpath);
+            yield inputRpcUrlXpath.type(params.rpc);
+            // Type input chain id
+            const [inputChainIdXpath] = yield page.$x(C.elements.add_new_network.input_chain_id_xpath);
+            yield inputChainIdXpath.type(String(params.chainId));
+            // Type currency symbol
+            const [inputCurrencySymbolXpath] = yield page.$x(C.elements.add_new_network.input_currency_symbol_xpath);
+            yield inputCurrencySymbolXpath.type(String(params.symbol));
+            // Type Explorer
+            const [inputExplorerXpath] = yield page.$x(C.elements.add_new_network.input_explorer_xpath);
+            yield inputExplorerXpath.type(String(params.explorer));
             yield page.waitForTimeout(2000);
-            yield page.click(C.elements.switch_network.div_network_display);
-            yield page.evaluate((options) => {
-                const C = options['config'];
-                let network = options['network'];
-                [...document.querySelectorAll(C.elements.switch_network.div_dropdown_network_list)].find(element => (new RegExp(network)).test(element.textContent)).click();
-            }, {
-                'network': "Custom RPC",
-                'config': C
-            });
-            // Network Name
-            yield page.waitForSelector(C.elements.add_new_network.input_network_name, { timeout: 15000 });
-            yield page.type(C.elements.add_new_network.input_network_name, params.networkName);
-            // RPC URL
-            yield page.waitForSelector(C.elements.add_new_network.input_rpc_url, { timeout: 15000 });
-            yield page.type(C.elements.add_new_network.input_rpc_url, params.rpc);
-            // Chain ID
-            if (params.chainId != null) {
-                yield page.waitForSelector(C.elements.add_new_network.input_chain_id, { timeout: 15000 });
-                yield page.type(C.elements.add_new_network.input_chain_id, (params.chainId).toString());
-            }
-            // Currency Symbol
-            if (params.symbol != null) {
-                yield page.waitForSelector(C.elements.add_new_network.input_currency_symbol, { timeout: 15000 });
-                yield page.type(C.elements.add_new_network.input_currency_symbol, (params.symbol).toString());
-            }
-            // BlockChain Url
-            if (params.explorer != null) {
-                yield page.waitForSelector(C.elements.add_new_network.input_block_explorer_url, { timeout: 15000 });
-                yield page.type(C.elements.add_new_network.input_block_explorer_url, (params.explorer).toString());
-            }
-            yield page.waitForXPath(C.elements.add_new_network.button_save_xpath + "[not(@disabled)]", { visible: true });
-            const [buttonSave] = yield page.$x(C.elements.add_new_network.button_save_xpath);
-            yield buttonSave.click();
-            yield page.waitForTimeout(2000);
-            yield page.click(C.elements.add_new_network.div_close_button);
+            const [buttonSaveXpath] = yield page.$x(C.elements.add_new_network.button_save_xpath);
+            yield buttonSaveXpath.click();
             return true;
         }
         catch (error) {

--- a/dist/Metamask/Libs/loadTokenContracts.js
+++ b/dist/Metamask/Libs/loadTokenContracts.js
@@ -23,12 +23,11 @@ function loadTokenContracts(params) {
             let addTokenUrl = [
                 C.urls.prefix,
                 currentUrl.match(/\/\/(.*?)\//i)[1],
-                "/home.html#add-token"
+                "/home.html#import-token"
             ].join("");
             for (let index in tokenContracts) {
                 yield page.goto(addTokenUrl, { waitUntil: 'networkidle0' });
                 yield page.waitForTimeout(1000);
-                // check if <button>Search</button> <button>Custom Token</button> (Usually happens in windows 10 as per testing)
                 let isSearchAndCustomToken = yield page.evaluate((options) => {
                     const C = options['config'];
                     return document.querySelectorAll(C.elements.add_token.button_search_and_add_token).length >= 2 ? true : false;
@@ -65,12 +64,12 @@ function loadTokenContracts(params) {
                     yield page.focus(C.elements.add_token.input_custom_decimals);
                     yield page.type(C.elements.add_token.input_custom_decimals, (tokenContract['decimals']).toString());
                 }
-                yield page.waitForXPath(C.elements.add_token.button_next_xpath + "[not(@disabled)]");
-                const [buttonNext] = yield page.$x(C.elements.add_token.button_next_xpath);
-                yield buttonNext.click();
                 yield page.waitForXPath(C.elements.add_token.button_add_token_xpath + "[not(@disabled)]");
                 const [buttonAddTokens] = yield page.$x(C.elements.add_token.button_add_token_xpath);
                 yield buttonAddTokens.click();
+                yield page.waitForXPath(C.elements.add_token.button_import_tokens_xpath + "[not(@disabled)]");
+                const [buttonImportTokens] = yield page.$x(C.elements.add_token.button_import_tokens_xpath);
+                yield buttonImportTokens.click();
                 yield page.waitForNavigation();
             }
         }

--- a/dist/Metamask/Libs/switchNetwork.js
+++ b/dist/Metamask/Libs/switchNetwork.js
@@ -24,8 +24,8 @@ function switchNetwork(params) {
             yield page.waitForTimeout(2000);
             yield page.evaluate((options) => {
                 const C = options['config'];
-                let network = options['network'];
-                let networkSlugged = (network).toLowerCase().replaceAll(" ", "-");
+                let network = String(options['network']);
+                let networkSlugged = network.toLowerCase().replaceAll(" ", "-");
                 [...document.querySelectorAll(C.elements.switch_network.div_dropdown_network_list)].find(element => {
                     let elementSlugged = element.textContent.toLowerCase().replaceAll(" ", "-");
                     return elementSlugged === networkSlugged;

--- a/dist/Metamask/metaMask.js
+++ b/dist/Metamask/metaMask.js
@@ -123,7 +123,7 @@ class Metamask {
                 yield this.addNewNetworks();
                 // switch to preferred network
                 //logger.write({content: `Switch network: ${C.network_preferred}`});
-                // await this.switchNetwork(C.network_preferred);
+                yield this.switchNetwork(constants_1.default.network_preferred);
                 yield this.page.waitForTimeout(2000);
                 // load tokens
                 yield this.loadTokenContracts();
@@ -161,16 +161,6 @@ class Metamask {
             for (let index in newNetworks) {
                 let network = newNetworks[index];
                 logger_1.default.write({ content: `Adding new networks ${network.slug}...` });
-                /*
-                 * Disabled
-                await this.metamask.addNetwork({
-                    networkName: network.slug,
-                    rpc: network.rpc_url,
-                    chainId: network.chain_id,
-                    symbol: network.currency_symbol,
-                    explorer: network.block_explorer_url,
-                });
-                 */
                 yield lib_1.default.addNewNetwork({
                     page: this.page,
                     C: constants_1.default,

--- a/dist/constants.js
+++ b/dist/constants.js
@@ -33,7 +33,7 @@ module.exports = {
     urls: {
         "prefix": "chrome-extension://",
     },
-    metamask_version: 'v10.1.1',
+    metamask_version: 'v10.15.0',
     network_preferred: config.PREFERRED_NETWORK,
     headless_browser: Boolean(parseInt((_b = config.HEADLESS_BROWSER) !== null && _b !== void 0 ? _b : 0)),
     networks: [
@@ -65,12 +65,20 @@ module.exports = {
             div_dropdown_network_list: ".menu-droppo .dropdown-menu-item",
         },
         add_new_network: {
+            button_add_a_network_xpath: "//button[contains(text(), 'Add a network')]",
+            input_network_name_xpath: "//h6[contains(.,'Network Name')]/parent::node()/parent::node()/following-sibling::input",
+            input_rpc_url_xpath: "//h6[contains(.,'New RPC URL')]/parent::node()/parent::node()/following-sibling::input",
+            input_chain_id_xpath: "//h6[contains(.,'Chain ID')]/parent::node()/parent::node()/following-sibling::input",
+            input_currency_symbol_xpath: "//h6[contains(.,'Currency Symbol')]/parent::node()/parent::node()/following-sibling::input",
+            input_explorer_xpath: "//h6[contains(.,'Block Explorer URL')]/parent::node()/parent::node()/following-sibling::input",
+            /*
             input_network_name: "#network-name",
             input_rpc_url: "#rpc-url",
             input_chain_id: "#chainId",
             input_currency_symbol: "#network-ticker",
             input_block_explorer_url: "#block-explorer-url",
             div_close_button: ".settings-page__close-button",
+            */
             button_save_xpath: "//button[contains(text(), 'Save')]",
         },
         add_token: {
@@ -80,7 +88,8 @@ module.exports = {
             input_custom_symbol: "#custom-symbol",
             input_custom_decimals: "#custom-decimals",
             button_next_xpath: "//button[contains(text(), 'Next')]",
-            button_add_token_xpath: "//button[contains(text(), 'Add Tokens')]"
+            button_add_token_xpath: "//button[contains(text(), 'Add Custom Token')]",
+            button_import_tokens_xpath: "//button[contains(text(), 'Import Tokens')]",
         },
         swap_token: {
             div_max_button: ".build-quote__max-button",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "crypto-bot-trader",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "ISC",
       "dependencies": {
-        "@chainsafe/dappeteer": "2.3.0",
+        "@chainsafe/dappeteer": "3.0.0-rc.0",
         "api.coinmarketcap": "^1.0.1",
         "cryptr": "^6.0.2",
         "forever": "^4.0.1",
@@ -25,14 +25,16 @@
       }
     },
     "node_modules/@chainsafe/dappeteer": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/dappeteer/-/dappeteer-2.3.0.tgz",
-      "integrity": "sha512-FDfdBLZIkkbx5nPQ+qpRr5oJgPs6H76KYz7jc2pKH17DcbiNtaF+egJA+wp+Lgsey7KYuK4W/0ttCsC0UBKw4w==",
+      "version": "3.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/dappeteer/-/dappeteer-3.0.0-rc.0.tgz",
+      "integrity": "sha512-sH5e0yMmWFkaYjqm4a9YWZFuaP8yjGhxVzOws8THdrjteLWE9DgzqVYUQb6YxGj8hiCsD+3Zwuc6X2DudPwzCA==",
       "dependencies": {
+        "@types/chai-as-promised": "^7.1.5",
+        "chai-as-promised": "^7.1.1",
         "node-stream-zip": "^1.13.0"
       },
       "peerDependencies": {
-        "puppeteer": ">5"
+        "puppeteer": ">13"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {
@@ -80,6 +82,19 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/@types/chai": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+      "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ=="
+    },
+    "node_modules/@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dependencies": {
+        "@types/chai": "*"
+      }
+    },
     "node_modules/@types/lodash": {
       "version": "4.14.178",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
@@ -94,9 +109,9 @@
       "peer": true
     },
     "node_modules/@types/yauzl": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
-      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -200,6 +215,15 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/assign-symbols": {
@@ -438,7 +462,7 @@
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "peer": true,
       "engines": {
         "node": "*"
@@ -469,6 +493,43 @@
       "integrity": "sha1-83odbqEOgp2UchrimpC7T7Uqt2c=",
       "dependencies": {
         "tape": "~2.3.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "peer": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dependencies": {
+        "check-error": "^1.0.2"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 5"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -661,6 +722,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "peer": true,
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
     "node_modules/crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
@@ -683,9 +753,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "peer": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -705,6 +775,18 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "peer": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/deep-equal": {
@@ -730,9 +812,9 @@
       "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4="
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.937139",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.937139.tgz",
-      "integrity": "sha512-daj+rzR3QSxsPRy5vjjthn58axO8c11j58uY0lG5vvlJk/EiOdCWOptGdkXDjtuRHr78emKq0udHCXM4trhoDQ==",
+      "version": "0.0.1011705",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1011705.tgz",
+      "integrity": "sha512-OKvTvu9n3swmgYshvsyVHYX0+aPzCoYUnyXUacfQMmFtBtBKewV/gT4I9jkAbpTqtTi2E4S9MXLlvzBDUlqg0Q==",
       "peer": true
     },
     "node_modules/diff": {
@@ -951,7 +1033,7 @@
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "peer": true,
       "dependencies": {
         "pend": "~1.2.0"
@@ -1121,6 +1203,15 @@
         "node": ">= 4.0"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -1225,9 +1316,9 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "peer": true,
       "dependencies": {
         "agent-base": "6",
@@ -1494,6 +1585,15 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "peer": true,
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
+    },
     "node_modules/make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -1749,15 +1849,23 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-stream-zip": {
@@ -1990,6 +2098,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -2001,7 +2118,7 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "peer": true
     },
     "node_modules/pify": {
@@ -2120,27 +2237,27 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-12.0.1.tgz",
-      "integrity": "sha512-YQ3GRiyZW0ddxTW+iiQcv2/8TT5c3+FcRUCg7F8q2gHqxd5akZN400VRXr9cHQKLWGukmJLDiE72MrcLK9tFHQ==",
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.4.0.tgz",
+      "integrity": "sha512-wxJRbofjaycCaQ9fhABlToJobrjxlABiFi6NvdkOPVJMYFblxDlDTjkg+b6bZYi7xN+lEXn84GBZsA5DYb3wfw==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
-        "debug": "4.3.2",
-        "devtools-protocol": "0.0.937139",
+        "cross-fetch": "3.1.5",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.1011705",
         "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.0",
-        "node-fetch": "2.6.5",
+        "https-proxy-agent": "5.0.1",
         "pkg-dir": "4.2.0",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.2.3"
+        "ws": "8.8.0"
       },
       "engines": {
-        "node": ">=10.18.1"
+        "node": ">=14.1.0"
       }
     },
     "node_modules/read": {
@@ -2790,7 +2907,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "peer": true
     },
     "node_modules/ts-node": {
@@ -2832,6 +2949,15 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/typescript": {
@@ -2989,13 +3115,13 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "peer": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
@@ -3056,9 +3182,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
       "peer": true,
       "engines": {
         "node": ">=10.0.0"
@@ -3096,7 +3222,7 @@
     "node_modules/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "peer": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
@@ -3115,10 +3241,12 @@
   },
   "dependencies": {
     "@chainsafe/dappeteer": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/dappeteer/-/dappeteer-2.3.0.tgz",
-      "integrity": "sha512-FDfdBLZIkkbx5nPQ+qpRr5oJgPs6H76KYz7jc2pKH17DcbiNtaF+egJA+wp+Lgsey7KYuK4W/0ttCsC0UBKw4w==",
+      "version": "3.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/dappeteer/-/dappeteer-3.0.0-rc.0.tgz",
+      "integrity": "sha512-sH5e0yMmWFkaYjqm4a9YWZFuaP8yjGhxVzOws8THdrjteLWE9DgzqVYUQb6YxGj8hiCsD+3Zwuc6X2DudPwzCA==",
       "requires": {
+        "@types/chai-as-promised": "^7.1.5",
+        "chai-as-promised": "^7.1.1",
         "node-stream-zip": "^1.13.0"
       }
     },
@@ -3161,6 +3289,19 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/chai": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+      "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ=="
+    },
+    "@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
     "@types/lodash": {
       "version": "4.14.178",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
@@ -3175,9 +3316,9 @@
       "peer": true
     },
     "@types/yauzl": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
-      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "optional": true,
       "peer": true,
       "requires": {
@@ -3257,6 +3398,12 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "peer": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -3437,7 +3584,7 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "peer": true
     },
     "cache-base": {
@@ -3463,6 +3610,34 @@
       "requires": {
         "tape": "~2.3.2"
       }
+    },
+    "chai": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "peer": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA=="
     },
     "chokidar": {
       "version": "2.1.8",
@@ -3618,6 +3793,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "peer": true,
+      "requires": {
+        "node-fetch": "2.6.7"
+      }
+    },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
@@ -3634,9 +3818,9 @@
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "peer": true,
       "requires": {
         "ms": "2.1.2"
@@ -3646,6 +3830,15 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "peer": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
     },
     "deep-equal": {
       "version": "0.1.2",
@@ -3667,9 +3860,9 @@
       "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4="
     },
     "devtools-protocol": {
-      "version": "0.0.937139",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.937139.tgz",
-      "integrity": "sha512-daj+rzR3QSxsPRy5vjjthn58axO8c11j58uY0lG5vvlJk/EiOdCWOptGdkXDjtuRHr78emKq0udHCXM4trhoDQ==",
+      "version": "0.0.1011705",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1011705.tgz",
+      "integrity": "sha512-OKvTvu9n3swmgYshvsyVHYX0+aPzCoYUnyXUacfQMmFtBtBKewV/gT4I9jkAbpTqtTi2E4S9MXLlvzBDUlqg0Q==",
       "peer": true
     },
     "diff": {
@@ -3847,7 +4040,7 @@
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "peer": true,
       "requires": {
         "pend": "~1.2.0"
@@ -3968,6 +4161,12 @@
         "nan": "^2.12.1"
       }
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "peer": true
+    },
     "get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -4049,9 +4248,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "peer": true,
       "requires": {
         "agent-base": "6",
@@ -4243,6 +4442,15 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "peer": true,
+      "requires": {
+        "get-func-name": "^2.0.0"
+      }
     },
     "make-dir": {
       "version": "1.3.0",
@@ -4453,9 +4661,9 @@
       "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ="
     },
     "node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "peer": true,
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -4635,6 +4843,12 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "peer": true
+    },
     "pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -4646,7 +4860,7 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "peer": true
     },
     "pify": {
@@ -4737,23 +4951,23 @@
       }
     },
     "puppeteer": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-12.0.1.tgz",
-      "integrity": "sha512-YQ3GRiyZW0ddxTW+iiQcv2/8TT5c3+FcRUCg7F8q2gHqxd5akZN400VRXr9cHQKLWGukmJLDiE72MrcLK9tFHQ==",
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.4.0.tgz",
+      "integrity": "sha512-wxJRbofjaycCaQ9fhABlToJobrjxlABiFi6NvdkOPVJMYFblxDlDTjkg+b6bZYi7xN+lEXn84GBZsA5DYb3wfw==",
       "peer": true,
       "requires": {
-        "debug": "4.3.2",
-        "devtools-protocol": "0.0.937139",
+        "cross-fetch": "3.1.5",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.1011705",
         "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.0",
-        "node-fetch": "2.6.5",
+        "https-proxy-agent": "5.0.1",
         "pkg-dir": "4.2.0",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.2.3"
+        "ws": "8.8.0"
       }
     },
     "read": {
@@ -5270,7 +5484,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "peer": true
     },
     "ts-node": {
@@ -5292,6 +5506,12 @@
         "make-error": "^1.1.1",
         "yn": "3.1.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "peer": true
     },
     "typescript": {
       "version": "4.5.2",
@@ -5415,13 +5635,13 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "peer": true
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "peer": true,
       "requires": {
         "tr46": "~0.0.3",
@@ -5475,9 +5695,9 @@
       }
     },
     "ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
       "peer": true,
       "requires": {}
     },
@@ -5497,7 +5717,7 @@
     "yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "peer": true,
       "requires": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crypto-bot-trader",
   "description": "swapping of ERC-20 Tokens (buy/sell) based on the market health with bot strategy (condition) - by utilizing metamask & pupeteer",
-  "version": "2.3.0",
+  "version": "2.3.5",
   "main": "./dist/index.js",
   "repository": {
     "type": "git",
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/marcelooblan2016/crypto-bot-trader.git#readme",
   "dependencies": {
-    "@chainsafe/dappeteer": "2.3.0",
+    "@chainsafe/dappeteer": "3.0.0-rc.0",
     "api.coinmarketcap": "^1.0.1",
     "cryptr": "^6.0.2",
     "forever": "^4.0.1",

--- a/src/Metamask/Libs/addNewNetwork.ts
+++ b/src/Metamask/Libs/addNewNetwork.ts
@@ -26,46 +26,34 @@ async function addNewNetwork(params: addNewNetworkParameters): Promise<boolean> 
     let currentUrl: string = page!.url();
 
     try {
-        await page!.waitForTimeout(2000);
-        await page!.click(C.elements.switch_network.div_network_display);
-
-        await page!.evaluate((options) => {
-            const C = options['config'];
-            let network = options['network'];
-            
-            [...document.querySelectorAll(C.elements.switch_network.div_dropdown_network_list)].find(element => (new RegExp(network)).test(element.textContent) ).click();
-        }, {
-            'network': "Custom RPC",
-            'config': C
-        });
-        
-        // Network Name
-        await page!.waitForSelector(C.elements.add_new_network.input_network_name , {timeout: 15000});
-        await page!.type(C.elements.add_new_network.input_network_name , params.networkName);
-        // RPC URL
-        await page!.waitForSelector(C.elements.add_new_network.input_rpc_url , {timeout: 15000});
-        await page!.type(C.elements.add_new_network.input_rpc_url , params.rpc);
-        // Chain ID
-        if (params.chainId != null) {
-            await page!.waitForSelector(C.elements.add_new_network.input_chain_id , {timeout: 15000});
-            await page!.type(C.elements.add_new_network.input_chain_id , (params.chainId).toString());
-        }
-        // Currency Symbol
-        if (params.symbol != null) {
-            await page!.waitForSelector(C.elements.add_new_network.input_currency_symbol , {timeout: 15000});
-            await page!.type(C.elements.add_new_network.input_currency_symbol , (params.symbol).toString());
-        }
-        // BlockChain Url
-        if (params.explorer !=  null) {
-            await page!.waitForSelector(C.elements.add_new_network.input_block_explorer_url , {timeout: 15000});
-            await page!.type(C.elements.add_new_network.input_block_explorer_url , (params.explorer).toString());
-        }
-
-        await page!.waitForXPath(C.elements.add_new_network.button_save_xpath + "[not(@disabled)]", { visible: true });
-        const [buttonSave] = await page!.$x(C.elements.add_new_network.button_save_xpath);
-        await buttonSave.click();
-        await page!.waitForTimeout(2000);
-        await page!.click(C.elements.add_new_network.div_close_button);
+        let networkUrl: string = [
+            C.urls.prefix,
+            currentUrl.match(/\/\/(.*?)\//i)![1],
+            `/home.html#settings/networks`
+        ].join("");
+        await page!.goto(networkUrl, { waitUntil: 'domcontentloaded' });
+        // click add new network
+        await page!.waitForXPath(C.elements.add_new_network.button_add_a_network_xpath + "[not(@disabled)]", { visible: true });
+        const [buttonAddNewNetwork]: any = await page!.$x(C.elements.add_new_network.button_add_a_network_xpath);
+        await buttonAddNewNetwork.click();
+        // Type Network Name
+        const [inputNetworkNameXpath] = await page!.$x(C.elements.add_new_network.input_network_name_xpath);
+        await inputNetworkNameXpath.type(params.networkName);
+        // Type input rpc url
+        const [inputRpcUrlXpath] = await page!.$x(C.elements.add_new_network.input_rpc_url_xpath);
+        await inputRpcUrlXpath.type(params.rpc);
+        // Type input chain id
+        const [inputChainIdXpath] = await page!.$x(C.elements.add_new_network.input_chain_id_xpath);
+        await inputChainIdXpath.type(String(params.chainId));
+        // Type currency symbol
+        const [inputCurrencySymbolXpath] = await page!.$x(C.elements.add_new_network.input_currency_symbol_xpath);
+        await inputCurrencySymbolXpath.type(String(params.symbol));
+        // Type Explorer
+        const [inputExplorerXpath] = await page!.$x(C.elements.add_new_network.input_explorer_xpath);
+        await inputExplorerXpath.type(String(params.explorer));
+        await page!.waitForTimeout(2000)
+        const [buttonSaveXpath]: any = await page!.$x(C.elements.add_new_network.button_save_xpath);
+        await buttonSaveXpath.click();
 
         return true;
     } catch (error) {

--- a/src/Metamask/Libs/getBalances.ts
+++ b/src/Metamask/Libs/getBalances.ts
@@ -109,7 +109,7 @@ async function getBalanceAll(params: getBalanceParameters): Promise<boolean|mapp
         
         if (isClickButtonAssets == true) {
             await page!.waitForXPath(C.elements.get_balances.button_assets_xpath, { visible: true });
-            const [buttonAssets] = await page!.$x(C.elements.get_balances.button_assets_xpath);
+            const [buttonAssets]: any = await page!.$x(C.elements.get_balances.button_assets_xpath);
             await buttonAssets.click();
         }
 

--- a/src/Metamask/Libs/loadTokenContracts.ts
+++ b/src/Metamask/Libs/loadTokenContracts.ts
@@ -13,13 +13,12 @@ async function loadTokenContracts(params: MetamaskLibLoadTokenContractsParameter
         let addTokenUrl: string = [
             C.urls.prefix,
             currentUrl.match(/\/\/(.*?)\//i)![1],
-            "/home.html#add-token"
+            "/home.html#import-token"
         ].join("");
 
         for(let index in tokenContracts) {
             await page!.goto(addTokenUrl, {waitUntil: 'networkidle0'});
             await page!.waitForTimeout(1000);
-            // check if <button>Search</button> <button>Custom Token</button> (Usually happens in windows 10 as per testing)
             let isSearchAndCustomToken: boolean = await page!.evaluate((options) => {
             const C = options['config'];
                 return document.querySelectorAll(C.elements.add_token.button_search_and_add_token).length >= 2 ? true : false;
@@ -27,7 +26,7 @@ async function loadTokenContracts(params: MetamaskLibLoadTokenContractsParameter
 
             if (isSearchAndCustomToken === true) {
                 await page!.waitForXPath(C.elements.add_token.button_custom_token_xpath);
-                const [buttonCustomAddToken] = await page!.$x(C.elements.add_token.button_custom_token_xpath);
+                const [buttonCustomAddToken]: any = await page!.$x(C.elements.add_token.button_custom_token_xpath);
                 await buttonCustomAddToken.click();
             }
 
@@ -58,13 +57,14 @@ async function loadTokenContracts(params: MetamaskLibLoadTokenContractsParameter
                 await page!.focus(C.elements.add_token.input_custom_decimals);
                 await page!.type(C.elements.add_token.input_custom_decimals, (tokenContract['decimals']).toString());
             }
-
-            await page!.waitForXPath(C.elements.add_token.button_next_xpath + "[not(@disabled)]");
-            const [buttonNext] = await page!.$x(C.elements.add_token.button_next_xpath);
-            await buttonNext.click();
+            
             await page!.waitForXPath(C.elements.add_token.button_add_token_xpath + "[not(@disabled)]");
-            const [buttonAddTokens] = await page!.$x(C.elements.add_token.button_add_token_xpath);
+            const [buttonAddTokens]: any = await page!.$x(C.elements.add_token.button_add_token_xpath);
             await buttonAddTokens.click();
+
+            await page!.waitForXPath(C.elements.add_token.button_import_tokens_xpath + "[not(@disabled)]");
+            const [buttonImportTokens]: any = await page!.$x(C.elements.add_token.button_import_tokens_xpath);
+            await buttonImportTokens.click();
             await page!.waitForNavigation();
         }
     } catch (error) {

--- a/src/Metamask/Libs/swapToken.ts
+++ b/src/Metamask/Libs/swapToken.ts
@@ -47,7 +47,7 @@ async function swapToken(params: SwapTokenParameters): Promise<boolean> {
         ].join("");
         await page!.goto(tokenFromBaseUrl, { waitUntil: 'domcontentloaded' });
         await page!.waitForXPath(C.elements.swap_token.button_swap_overview_xpath + "[not(@disabled)]", { visible: true });
-        const [buttonSwapOverview] = await page!.$x(C.elements.swap_token.button_swap_overview_xpath);
+        const [buttonSwapOverview]: any = await page!.$x(C.elements.swap_token.button_swap_overview_xpath);
         await buttonSwapOverview.click();
         await page!.waitForTimeout(1000);
         // click swap from overview
@@ -148,7 +148,7 @@ async function swapToken(params: SwapTokenParameters): Promise<boolean> {
         }
 
         await page!.waitForXPath(C.elements.swap_token.button_swap_review_xpath + "[not(@disabled)]", { visible: true });
-        const [buttonSwapReview] = await page!.$x(C.elements.swap_token.button_swap_review_xpath);
+        const [buttonSwapReview]: any = await page!.$x(C.elements.swap_token.button_swap_review_xpath);
         await buttonSwapReview.click();
         await page!.waitForNavigation();
         
@@ -165,11 +165,11 @@ async function swapToken(params: SwapTokenParameters): Promise<boolean> {
         }
 
         await page!.waitForXPath(C.elements.swap_token.button_swap_xpath + "[not(@disabled)]", { visible: true });
-        const [buttonSwap] = await page!.$x(C.elements.swap_token.button_swap_xpath);
+        const [buttonSwap]: any = await page!.$x(C.elements.swap_token.button_swap_xpath);
         await buttonSwap.click();
         await page!.waitForNavigation();
         await page!.waitForXPath(C.elements.swap_token.div_transaction_complete_xpath, { visible: true, timeout: 60000 });
-        const [buttonClose] = await page!.$x(C.elements.swap_token.button_close_xpath);
+        const [buttonClose]: any = await page!.$x(C.elements.swap_token.button_close_xpath);
         await buttonClose.click();
         await page!.waitForNavigation();
 
@@ -208,7 +208,7 @@ async function swapToken(params: SwapTokenParameters): Promise<boolean> {
         logger.write({content: "Swapping token: failed"});
         logger.screenshot(page!);
 
-        const [buttonSwapCancel] = await page!.$x(C.elements.swap_token.button_swap_cancel_xpath);
+        const [buttonSwapCancel]: any = await page!.$x(C.elements.swap_token.button_swap_cancel_xpath);
         await buttonSwapCancel.click();
     }
 

--- a/src/Metamask/Libs/switchNetwork.ts
+++ b/src/Metamask/Libs/switchNetwork.ts
@@ -19,8 +19,8 @@ async function switchNetwork(params: switchNetworkParameters): Promise<boolean> 
 
         await page!.evaluate((options) => {
             const C = options['config'];
-            let network = options['network'];
-            let networkSlugged = (network).toLowerCase().replaceAll(" ", "-");
+            let network: any = String(options['network']);
+            let networkSlugged = network.toLowerCase().replaceAll(" ", "-");
             [...document.querySelectorAll(C.elements.switch_network.div_dropdown_network_list)].find(element => {
                 let elementSlugged = element.textContent.toLowerCase().replaceAll(" ", "-");
                 return elementSlugged === networkSlugged

--- a/src/Metamask/metaMask.ts
+++ b/src/Metamask/metaMask.ts
@@ -109,7 +109,7 @@ class Metamask implements MetamaskInterface {
             await this.addNewNetworks();
             // switch to preferred network
             //logger.write({content: `Switch network: ${C.network_preferred}`});
-            // await this.switchNetwork(C.network_preferred);
+            await this.switchNetwork(C.network_preferred);
             await this.page!.waitForTimeout(2000);
             // load tokens
             await this.loadTokenContracts();
@@ -145,16 +145,6 @@ class Metamask implements MetamaskInterface {
             let network = newNetworks[index];
 
             logger.write({content: `Adding new networks ${network.slug}...`});
-            /*
-             * Disabled
-            await this.metamask.addNetwork({
-                networkName: network.slug,
-                rpc: network.rpc_url,
-                chainId: network.chain_id,
-                symbol: network.currency_symbol,
-                explorer: network.block_explorer_url,
-            });
-             */
 
             await metaMaskLibs.addNewNetwork({
                 page: this.page,

--- a/src/constants.js
+++ b/src/constants.js
@@ -39,7 +39,7 @@ module.exports = {
     urls: {
         "prefix": "chrome-extension://",
     },
-    metamask_version: 'v10.1.1',
+    metamask_version: 'v10.15.0',
     network_preferred: config.PREFERRED_NETWORK,
     headless_browser: Boolean( parseInt(config.HEADLESS_BROWSER ?? 0) ),
     networks: [
@@ -71,12 +71,20 @@ module.exports = {
             div_dropdown_network_list: ".menu-droppo .dropdown-menu-item",
         },
         add_new_network: {
+            button_add_a_network_xpath: "//button[contains(text(), 'Add a network')]",
+            input_network_name_xpath: "//h6[contains(.,'Network Name')]/parent::node()/parent::node()/following-sibling::input",
+            input_rpc_url_xpath: "//h6[contains(.,'New RPC URL')]/parent::node()/parent::node()/following-sibling::input",
+            input_chain_id_xpath: "//h6[contains(.,'Chain ID')]/parent::node()/parent::node()/following-sibling::input",
+            input_currency_symbol_xpath: "//h6[contains(.,'Currency Symbol')]/parent::node()/parent::node()/following-sibling::input",
+            input_explorer_xpath: "//h6[contains(.,'Block Explorer URL')]/parent::node()/parent::node()/following-sibling::input",
+            /*
             input_network_name: "#network-name",
             input_rpc_url: "#rpc-url",
             input_chain_id: "#chainId",
             input_currency_symbol: "#network-ticker",
             input_block_explorer_url: "#block-explorer-url",
             div_close_button: ".settings-page__close-button",
+            */
             button_save_xpath: "//button[contains(text(), 'Save')]",
         },
         add_token: {
@@ -86,7 +94,8 @@ module.exports = {
             input_custom_symbol: "#custom-symbol",
             input_custom_decimals: "#custom-decimals",
             button_next_xpath: "//button[contains(text(), 'Next')]",
-            button_add_token_xpath: "//button[contains(text(), 'Add Tokens')]"
+            button_add_token_xpath: "//button[contains(text(), 'Add Custom Token')]",
+            button_import_tokens_xpath: "//button[contains(text(), 'Import Tokens')]",
         },
         swap_token: {
             div_max_button: ".build-quote__max-button",

--- a/test/main.js
+++ b/test/main.js
@@ -3,12 +3,12 @@ const {metaMask, trader, token} = require('../dist/index');
 (async function() {
     // // initiate 
     await metaMask.build();
-    const initiatedTrader = new trader({metamask_with_build: metaMask, token: token});
+    //const initiatedTrader = new trader({metamask_with_build: metaMask, token: token});
     
-    await initiatedTrader.analyzeMarket()
-    setInterval(async () => {
-        await initiatedTrader.analyzeMarket()
-    }, 300000);
+    // await initiatedTrader.analyzeMarket()
+    // setInterval(async () => {
+    //     await initiatedTrader.analyzeMarket()
+    // }, 300000);
     // every 5 minutes
 
 })();

--- a/test/swapToken.js
+++ b/test/swapToken.js
@@ -11,5 +11,5 @@ const {metaMask} = require('../dist/index');
         "Earned: 5 usd",
     ].join(" ");
     
-    await metaMask.swapToken("usdc", "matic", 1, 0, description);
+    await metaMask.swapToken("matic", "usdc", 1, 0, description);
 })();


### PR DESCRIPTION
Due to metamask update: forcing all to use at least ^10.15 many elements became unrecognized. This pr will be the fix for the adjustment required.